### PR TITLE
Refactor BlocProvider initialization for QuranCubit and BookmarksCubit 

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -18,6 +18,8 @@ migrate_working_dir/
 *.iws
 .idea/
 
+
+
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
@@ -32,6 +34,8 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 /build/
+pubspec.lock
+Podfile.lock
 
 # Symbolication related
 app.*.symbols

--- a/lib/src/app_bloc.dart
+++ b/lib/src/app_bloc.dart
@@ -8,8 +8,8 @@ class AppBloc {
   static final bookmarksCubit = BookmarksCubit();
 
   static final List<BlocProvider> providers = [
-    BlocProvider<QuranCubit>(create: (context) => quranCubit),
-    BlocProvider<BookmarksCubit>(create: (context) => bookmarksCubit),
+    BlocProvider<QuranCubit>.value(value: quranCubit),
+    BlocProvider<BookmarksCubit>.value(value: bookmarksCubit),
   ];
 
   static void dispose() {


### PR DESCRIPTION
This pull request contains a few minor updates to the project configuration and dependency management. The main changes are updates to the `.gitignore` file to exclude additional lock files, and a small refactor in the way Bloc providers are instantiated in `AppBloc`.

- **Bloc provider instantiation:**
  * Refactored `AppBloc.providers` to use `BlocProvider.value` instead of `BlocProvider(create:)`, which is more appropriate when providing existing cubit instances.